### PR TITLE
WIP: Refactor so this can be used by anybody!

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 This is based off of [@jfrazelle's](https://github.com/jfrazelle) awesome [updateforks](https://github.com/jfrazelle/dotfiles/blob/master/bin/updateforks) from her Dotfiles. I wanted to practice my Golang, so I took inspiration from her bash script and wrote it with stdlib go.
 
+## Usage
+
+```
+$ updateforks [FLAGS]
+```
+
+### Environment Variables
+
+
+
+### Flags
+
+- `--user=<username>` **Required** Your github username. This could be a user or an org, as long as you have permissions to push to that organzation.
+- `--uri` (default "https://api.github.com")
+- `--api-version` (default "v3")
+
 _Right now this only works for github, but in the future it could work for gitlab and bitbucket)_
 
 Update forks does the following:

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -163,13 +164,26 @@ func updateForks(repos []*Repo) error {
 }
 
 func main() {
-	log.Println("Updating forks.")
-	gh := &Github{
-		URI:        "https://api.github.com",
-		APIVersion: "v3",
+	var uri string
+	var apiVersion string
+	var user string
+	flag.StringVar(&uri, "uri", "https://api.github.com", "The Github URI to update forks on")
+	flag.StringVar(&apiVersion, "api-version", "v3", "The API version for the Github uri to update forks on")
+	flag.StringVar(&user, "user", "", "The GIthub user to update forks on")
+
+	flag.Parse()
+
+	if user == "" {
+		log.Println("You must provide a user with the --user flag to use updateforks")
+		return
 	}
 
-	repos, err := gh.GetRepos("chaseadamsio")
+	gh := &Github{
+		URI:        uri,
+		APIVersion: apiVersion,
+	}
+
+	repos, err := gh.GetRepos(user)
 
 	if err != nil {
 		log.Println(err)

--- a/main.go
+++ b/main.go
@@ -1,234 +1,39 @@
 package main
 
 import (
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"net/http"
+	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
+
+	"golang.org/x/oauth2"
+
+	"github.com/google/go-github/github"
 )
 
-type Github struct {
-	URI        string
-	APIVersion string
-	user       string
-	token      string
-	Repos      Repos
+const (
+	version = "1.0.0"
+)
+
+var client *github.Client
+
+type Fork struct {
+	Name          string
+	FullName      string
+	Owner         string
+	DefaultBranch string
+	UpstreamOwner string
 }
 
-type Repo struct {
-	ID            int    `json:"id"`
-	IsFork        bool   `json:"fork"`
-	Repo          string `json:"name"`
-	FullName      string `json:"full_name"`
-	DefaultBranch string `json:"default_branch"`
-	UpstreamName  string
-}
-
-type branch struct {
-	Commit struct {
-		SHA string `json:"sha"`
-	} `json:"commit"`
-}
-
-type Repos []Repo
-
-func (gh *Github) get(path string) ([]byte, error) {
-	requestURL := gh.URI + path
-	HTTPClient := new(http.Client)
-	*HTTPClient = *http.DefaultClient
-	req, err := http.NewRequest("GET", requestURL, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.SetBasicAuth(gh.token, "")
-	resp, err := HTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	return ioutil.ReadAll(resp.Body)
-}
-
-func (gh *Github) GetRepos() error {
-	fmt.Printf("Retrieving information about %s repos", gh.user)
-	path := filepath.Join("/users", gh.user, "repos")
-	body, err := gh.get(path)
-	if err != nil {
-		return err
-	}
-
-	json.Unmarshal(body, &gh.Repos)
-
-	for idx, repo := range gh.Repos {
-		if repo.IsFork {
-			err = gh.GetForkUpstream(&gh.Repos[idx])
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-func (gh *Github) GetForkUpstream(repo *Repo) error {
-	path := filepath.Join("/repos", repo.FullName)
-	body, err := gh.get(path)
-	if err != nil {
-		return err
-	}
-
-	var repoResp struct {
-		Parent struct {
-			Owner struct {
-				Login string `json:"login"`
-			} `json:"owner"`
-		} `json:"parent"`
-	}
-
-	json.Unmarshal(body, &repoResp)
-	repo.UpstreamName = repoResp.Parent.Owner.Login + "/" + repo.Repo
-	return nil
-}
-
-func (gh *Github) GetBranchLatestCommit(repoFullName string, branchName string) (*branch, error) {
-	path := filepath.Join("/repos", repoFullName, "branches", branchName)
-	body, err := gh.get(path)
-	if err != nil {
-		return nil, err
-	}
-
-	newBranch := new(branch)
-
-	json.Unmarshal(body, &newBranch)
-	return newBranch, nil
-}
-
-func (gh *Github) isCommitSynced(repo *Repo) (bool, error) {
-	fork, err := gh.GetBranchLatestCommit(repo.FullName, repo.DefaultBranch)
-	if err != nil {
-		return false, err
-	}
-
-	upstream, err := gh.GetBranchLatestCommit(repo.UpstreamName, repo.DefaultBranch)
-	if err != nil {
-		return false, err
-	}
-
-	if &fork.Commit == &upstream.Commit {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-func (gh *Github) updateFork(repo *Repo) error {
-	isSynced, err := gh.isCommitSynced(repo)
-	if err != nil {
-		return err
-	}
-
-	if isSynced {
-		fmt.Printf("%s is already synced with upstream", repo.FullName)
-		return nil
-	}
-	// Create a temporary directory
-	dir, err := ioutil.TempDir("", "tmp")
-	if err != nil {
-		return err
-	}
-	defer os.Remove(dir)
-	fmt.Printf("Beginning the process of updating %s in %s", repo.FullName, dir)
-
-	// Clone the git repo into the temporary directory
-	forkURL := fmt.Sprintf("git@github.com:%s.git", repo.FullName)
-	err = gitExec([]string{"clone", "--depth", "1", forkURL, dir})
-	if err != nil {
-		return err
-	}
-	fmt.Printf("Cloned %s into %s", repo.FullName, dir)
-
-	// Change into the temporary directcory
-	err = os.Chdir(dir)
-	if err != nil {
-		return err
-	}
-
-	upstreamURL := fmt.Sprintf("git@github.com:%s.git", repo.UpstreamName)
-	err = gitExec([]string{"remote", "add", "upstream", upstreamURL})
-	if err != nil {
-		return err
-	}
-	fmt.Printf("Added upstream remote for %s", repo.UpstreamName)
-
-	err = gitExec([]string{"remote", "-v", "update", "-p"})
-	if err != nil {
-		return err
-	}
-	fmt.Printf("Updated remote for upstream %s", repo.UpstreamName)
-
-	upstream := fmt.Sprintf("upstream/%s", repo.DefaultBranch)
-	err = gitExec([]string{"rebase", upstream})
-	if err != nil {
-		return err
-	}
-	fmt.Printf("Rebased off of upstream %s", repo.UpstreamName)
-
-	err = gitExec([]string{"push", "origin", repo.DefaultBranch})
-	if err != nil {
-		return err
-	}
-	fmt.Printf("Pushed %s origin/%s", repo.FullName, repo.DefaultBranch)
-	return nil
-}
-
-func (gh *Github) updateForks() error {
-	for idx, repo := range gh.Repos {
-		if !repo.IsFork {
-			continue
-		}
-
-		err := gh.updateFork(&gh.Repos[idx])
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func gitExec(args []string) error {
-	cmd := exec.Command("git", args...)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return err
-	}
-	if len(output) > 0 {
-		fmt.Println(string(output))
-	}
-	return nil
-}
-
-func main() {
+func init() {
 	var (
-		uri        = flag.String("uri", "https://api.github.com", "The Github URI to update forks on")
-		apiVersion = flag.String("api-version", "v3", "The API version for the Github uri to update forks on")
-		user       = flag.String("user", "", "The GIthub user to update forks on")
-		token      = flag.String("token", "", "The github user token to update fork on")
+		token = flag.String("token", "", "The github user token to update fork on")
 	)
 
 	flag.Parse()
-
-	if *user == "" {
-		fmt.Println(errors.New("You must provide a user with the --user flag to use updateforks"))
-		os.Exit(1)
-	}
 
 	if *token == "" {
 		if os.Getenv("GITHUB_TOKEN") == "" {
@@ -239,24 +44,188 @@ func main() {
 		*token = os.Getenv("GITHUB_TOKEN")
 	}
 
-	gh := &Github{
-		URI:        *uri,
-		APIVersion: *apiVersion,
-		user:       *user,
-		token:      *token,
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: *token},
+	)
+	tc := oauth2.NewClient(oauth2.NoContext, ts)
+
+	client = github.NewClient(tc)
+}
+
+type Repositories interface {
+	List(string, *github.RepositoryListOptions) ([]*github.Repository, *github.Response, error)
+	Get(string, string) (*github.Repository, *github.Response, error)
+	GetBranch(string, string, string) (*github.Branch, *github.Response, error)
+}
+
+func getAllRepositories(r Repositories) ([]*github.Repository, error) {
+	repos, _, err := r.List("", nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not list repositories: %v", err)
+	}
+	return repos, nil
+}
+
+func updateForkUpstream(r Repositories, f *Fork) error {
+	found, _, err := r.Get(f.Owner, f.Name)
+	if err != nil {
+		return fmt.Errorf("error getting repository: %s", err)
+	}
+	f.UpstreamOwner = *found.Parent.Owner.Login
+	return nil
+}
+
+func getBranchSHA(r Repositories, owner, name, branch string) (string, error) {
+	found, _, err := r.GetBranch(owner, name, branch)
+	if err != nil {
+		return "", fmt.Errorf("error getting fork branch: %s", err)
+	}
+	return *found.Commit.SHA, nil
+}
+
+func isForkUpToDateWithUpstream(r Repositories, f Fork) (bool, error) {
+	forkSHA, err := getBranchSHA(r, f.Owner, f.Name, f.DefaultBranch)
+	if err != nil {
+		return false, fmt.Errorf("error getting fork branch: %s", err)
 	}
 
-	err := gh.GetRepos()
+	upstreamSHA, err := getBranchSHA(r, f.UpstreamOwner, f.Name, f.DefaultBranch)
 	if err != nil {
-		fmt.Println(os.Stderr, err)
+		return false, fmt.Errorf("error getting upstream branch: %s", err)
+	}
+
+	if forkSHA == upstreamSHA {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func gitexec(args []string) error {
+	cmd := exec.Command("git", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+
+	if len(output) > 0 {
+		fmt.Println(string(output))
+	}
+
+	return nil
+}
+
+func generateSSHURL(owner, name string) string {
+	return "git@github.com:" + owner + "/" + name + ".git"
+}
+
+func Clone(f Fork, dir string) error {
+	cloneSSHURL := generateSSHURL(f.Owner, f.Name)
+	return gitexec([]string{"clone", "--depth", "1", cloneSSHURL, dir})
+}
+
+func AddUpstream(f Fork) error {
+	upstreamSSHURL := generateSSHURL(f.UpstreamOwner, f.Name)
+	return gitexec([]string{"remote", "add", "upstream", upstreamSSHURL})
+}
+
+func UpdateRemotes() error {
+	return gitexec([]string{"remote", "-v", "update", "-p"})
+}
+func RebaseForkFromUpstream(f Fork) error {
+	return gitexec([]string{"rebase", "upstream/" + f.DefaultBranch})
+}
+
+func PushFork(f Fork) error {
+	return gitexec([]string{"push", "origin", f.DefaultBranch})
+}
+
+func updateFork(fork Fork, dir string) error {
+	var err error
+	err = Clone(fork, dir)
+	if err != nil {
+		return fmt.Errorf("could not clone fork %s: %v", fork.FullName, err)
+	}
+
+	err = os.Chdir(dir)
+	if err != nil {
+		return fmt.Errorf("could not change dir: %s", err)
+	}
+
+	err = AddUpstream(fork)
+	if err != nil {
+		return fmt.Errorf("could not add upstream url for %s: %v", fork.FullName, err)
+	}
+
+	err = UpdateRemotes()
+	if err != nil {
+		return fmt.Errorf("could not update remote: %s", err)
+	}
+
+	err = RebaseForkFromUpstream(fork)
+	if err != nil {
+		return fmt.Errorf("could not rebase fork from upstream: %s", err)
+	}
+
+	err = PushFork(fork)
+	if err != nil {
+		return fmt.Errorf("could not push to remote: %s", err)
+	}
+
+	return nil
+
+}
+func main() {
+
+	repos, err := getAllRepositories(client.Repositories)
+	if err != nil {
+		fmt.Errorf("could not get all repositories: %s", err)
 		os.Exit(1)
 	}
 
-	err = gh.updateForks()
-	if err != nil {
-		fmt.Println(os.Stderr, err)
-		os.Exit(1)
+	forks := new([]Fork)
+
+	for _, repo := range repos {
+		if !*repo.Fork {
+			continue
+		}
+		fork := &Fork{
+			Name:          *repo.Name,
+			FullName:      *repo.FullName,
+			Owner:         *repo.Owner.Login,
+			DefaultBranch: *repo.DefaultBranch,
+		}
+
+		updateForkUpstream(client.Repositories, fork)
+		if err != nil {
+			log.Printf("could not get fork upstream for %s: %v", fork.Name, err)
+			continue
+		}
+
+		*forks = append(*forks, *fork)
 	}
 
-	fmt.Println("All forks have been updated.")
+	for _, fork := range *forks {
+		upToDate, err := isForkUpToDateWithUpstream(client.Repositories, fork)
+
+		if upToDate {
+			continue
+		}
+
+		fmt.Println(fork.Name, ":", fork.Owner, "commit does not match", fork.UpstreamOwner, "commit")
+
+		dir, err := ioutil.TempDir("", "tmp")
+		if err != nil {
+			fmt.Errorf("could not create a temporary directory: %s", err)
+			os.Exit(1)
+		}
+		defer os.RemoveAll(dir)
+
+		err = updateFork(fork, dir)
+		if err != nil {
+			fmt.Println("could not update fork %s: %v", fork.Name, err)
+			os.Exit(1)
+		}
+
+	}
 }

--- a/main.go
+++ b/main.go
@@ -164,26 +164,25 @@ func updateForks(repos []*Repo) error {
 }
 
 func main() {
-	var uri string
-	var apiVersion string
-	var user string
-	flag.StringVar(&uri, "uri", "https://api.github.com", "The Github URI to update forks on")
-	flag.StringVar(&apiVersion, "api-version", "v3", "The API version for the Github uri to update forks on")
-	flag.StringVar(&user, "user", "", "The GIthub user to update forks on")
+	var (
+		uri        = flag.String("uri", "https://api.github.com", "The Github URI to update forks on")
+		apiVersion = flag.String("api-version", "v3", "The API version for the Github uri to update forks on")
+		user       = flag.String("user", "", "The GIthub user to update forks on")
+	)
 
 	flag.Parse()
 
-	if user == "" {
+	if *user == "" {
 		log.Println("You must provide a user with the --user flag to use updateforks")
 		return
 	}
 
 	gh := &Github{
-		URI:        uri,
-		APIVersion: apiVersion,
+		URI:        *uri,
+		APIVersion: *apiVersion,
 	}
 
-	repos, err := gh.GetRepos(user)
+	repos, err := gh.GetRepos(*user)
 
 	if err != nil {
 		log.Println(err)

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func getAllRepositories(r Repositories) ([]*github.Repository, error) {
 func updateForkUpstream(r Repositories, f *Fork) error {
 	found, _, err := r.Get(f.Owner, f.Name)
 	if err != nil {
-		return fmt.Errorf("error getting repository: %s", err)
+		return fmt.Errorf("could not get repository: %s", err)
 	}
 	f.UpstreamOwner = *found.Parent.Owner.Login
 	return nil
@@ -51,7 +51,7 @@ func updateForkUpstream(r Repositories, f *Fork) error {
 func getBranchSHA(r Repositories, owner, name, branch string) (string, error) {
 	found, _, err := r.GetBranch(owner, name, branch)
 	if err != nil {
-		return "", fmt.Errorf("error getting fork branch: %s", err)
+		return "", fmt.Errorf("could not get fork branch: %s", err)
 	}
 	return *found.Commit.SHA, nil
 }
@@ -59,12 +59,12 @@ func getBranchSHA(r Repositories, owner, name, branch string) (string, error) {
 func isForkUpToDateWithUpstream(r Repositories, f Fork) (bool, error) {
 	forkSHA, err := getBranchSHA(r, f.Owner, f.Name, f.DefaultBranch)
 	if err != nil {
-		return false, fmt.Errorf("error getting fork branch: %s", err)
+		return false, fmt.Errorf("could not get fork branch SHA: %s", err)
 	}
 
 	upstreamSHA, err := getBranchSHA(r, f.UpstreamOwner, f.Name, f.DefaultBranch)
 	if err != nil {
-		return false, fmt.Errorf("error getting upstream branch: %s", err)
+		return false, fmt.Errorf("could not get upstream branch SHA: %s", err)
 	}
 
 	if forkSHA == upstreamSHA {

--- a/main.go
+++ b/main.go
@@ -30,6 +30,8 @@ type Repo struct {
 	} `json:"parent"`
 }
 
+type Repos []*Repo
+
 func (gh *Github) get(path string) ([]byte, error) {
 	client := http.Client{}
 	req, err := http.NewRequest("GET", gh.URI+path, nil)
@@ -53,7 +55,7 @@ func (gh *Github) GetRepos(user string) ([]*Repo, error) {
 		return nil, err
 	}
 
-	var repos []*Repo
+	repos := Repos{}
 
 	json.Unmarshal(body, &repos)
 

--- a/main_test.go
+++ b/main_test.go
@@ -211,7 +211,7 @@ func TestIsForkUpToDateWithUpstream(t *testing.T) {
 		expectedUpToDate    bool
 		expectedErrContains string
 	}{
-		{NewFakeRepositories("getBranchError"), *fork, false, "could not get fork branc SHA"},
+		{NewFakeRepositories("getBranchError"), *fork, false, "could not get fork branch SHA"},
 		{NewFakeRepositories("getUpstreamBranchError"), *fork, false, "could not get upstream branch SHA"},
 		{NewFakeRepositories("successUpToDate"), *fork, true, ""},
 		{NewFakeRepositories("successNotUpToDate"), *fork, false, ""},
@@ -228,5 +228,13 @@ func TestIsForkUpToDateWithUpstream(t *testing.T) {
 				t.Errorf("err getAllRepositories() expected: %s actual: %s", tc.expectedErrContains, actualErr)
 			}
 		}
+	}
+}
+
+func TestGenerateSSHURL(t *testing.T) {
+	expected := "git@github.com:chaseadamsio/updateforks.git"
+	actual := generateSSHURL("chaseadamsio", "updateforks")
+	if actual != expected {
+		t.Errorf("err generateSSHURL() expected: %s actual: %s", expected, actual)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,1 +1,232 @@
 package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/github"
+)
+
+type FakeRepositories struct {
+	respondsWith string
+}
+
+var jsonResponse = `
+		[{
+			"name": "updateforks",
+			"full_name": "chaseadamsiodownstream/updateforks",
+			"owner": {
+				"login": "chaseadamsiodownstream"
+			},
+			"default_branch": "master",
+			"parent": {
+				"owner": {
+					"login": "chaseadamsio"
+				}
+			}
+		}]
+		`
+var expectedRepositories = []*github.Repository{}
+
+func init() {
+	json.Unmarshal([]byte(jsonResponse), &expectedRepositories)
+}
+
+func (f *FakeRepositories) List(s string, lo *github.RepositoryListOptions) ([]*github.Repository, *github.Response, error) {
+	var err error
+	var repos []*github.Repository
+
+	switch f.respondsWith {
+	case "listError":
+		repos = nil
+		err = fmt.Errorf("listError")
+	case "success":
+		repos = expectedRepositories
+		err = nil
+	}
+	return repos, nil, err
+}
+
+func (f *FakeRepositories) Get(user string, repo string) (*github.Repository, *github.Response, error) {
+	var err error
+	var expectedRepo *github.Repository
+
+	switch f.respondsWith {
+	case "getError":
+		expectedRepo = nil
+		err = fmt.Errorf("getError")
+	case "success":
+		expectedRepo = expectedRepositories[0]
+		err = nil
+	}
+	return expectedRepo, nil, err
+}
+
+func (f *FakeRepositories) GetBranch(user string, repo string, branch string) (*github.Branch, *github.Response, error) {
+	var err error
+	var expectedBranch *github.Branch
+	var sha string
+
+	switch f.respondsWith {
+	case "getBranchError":
+		sha = ""
+		err = fmt.Errorf("getBranchError")
+	case "getUpstreamBranchError":
+		if user == "chaseadamsiodownstream" {
+			sha = "c52f25f54838f1052ed9418b65250b422c108926"
+		} else {
+			sha = ""
+			err = fmt.Errorf("getBranchError")
+		}
+	case "success":
+		sha = "c52f25f54838f1052ed9418b65250b422c108926"
+		err = nil
+	case "successUpToDate":
+		if user == "chaseadamsio" {
+			sha = "c52f25f54838f1052ed9418b65250b422c108926"
+		} else if user == "chaseadamsiodownstream" {
+			sha = "c52f25f54838f1052ed9418b65250b422c108926"
+		}
+		err = nil
+	case "successNotUpToDate":
+		if user == "chaseadamsio" {
+			sha = "c52f25f54838f1052ed9418b65250b422c108926"
+		} else if user == "chaseadamsiodownstream" {
+			sha = "1da994835c2c720b9666e646f48c78856141acb0"
+		}
+		err = nil
+	}
+	expectedBranch = &github.Branch{
+		Commit: &github.Commit{
+			SHA: &sha,
+		},
+	}
+	return expectedBranch, nil, err
+}
+
+func NewFakeRepositories(respondsWith string) *FakeRepositories {
+	return &FakeRepositories{
+		respondsWith: respondsWith,
+	}
+}
+
+func TestGetAllRepositories(t *testing.T) {
+	testCases := []struct {
+		fr                  *FakeRepositories
+		expected            []*github.Repository
+		expectedErrContains string
+	}{
+		{NewFakeRepositories("listError"), nil, "could not list repositories"},
+		{NewFakeRepositories("success"), expectedRepositories, ""},
+	}
+
+	for _, tc := range testCases {
+		actual, actualErr := getAllRepositories(tc.fr)
+		if !reflect.DeepEqual(tc.expected, actual) {
+			t.Errorf("deepequal getAllRepositories() expected: %s actual: %s", tc.expected, actual)
+		}
+
+		if actualErr != nil {
+			if !strings.Contains(actualErr.Error(), tc.expectedErrContains) {
+				t.Errorf("err getAllRepositories() expected: %s actual: %s", tc.expectedErrContains, actualErr)
+			}
+		}
+	}
+}
+
+func TestUpdateForkUpstream(t *testing.T) {
+	fork := &Fork{
+		Name:          *expectedRepositories[0].Name,
+		FullName:      *expectedRepositories[0].FullName,
+		Owner:         *expectedRepositories[0].Owner.Login,
+		DefaultBranch: *expectedRepositories[0].DefaultBranch,
+	}
+
+	expectedFork := *fork
+	expectedFork.UpstreamOwner = "chaseadamsio"
+
+	testCases := []struct {
+		fr                  *FakeRepositories
+		fork                *Fork
+		expected            *Fork
+		expectedErrContains string
+	}{
+		{NewFakeRepositories("getError"), &Fork{}, &Fork{}, "could not get repository"},
+		{NewFakeRepositories("success"), fork, &expectedFork, ""},
+	}
+
+	for _, tc := range testCases {
+		actualErr := updateForkUpstream(tc.fr, tc.fork)
+		if !reflect.DeepEqual(tc.expected, tc.fork) {
+			t.Errorf("deepequal getAllRepositories() expected: %s actual: %s", tc.expected, tc.fork)
+		}
+
+		if actualErr != nil {
+			if !strings.Contains(actualErr.Error(), tc.expectedErrContains) {
+				t.Errorf("err getAllRepositories() expected: %s actual: %s", tc.expectedErrContains, actualErr)
+			}
+		}
+	}
+}
+
+func TestGetBranchSHA(t *testing.T) {
+	testCases := []struct {
+		fr                  *FakeRepositories
+		expectedSHA         string
+		expectedErrContains string
+	}{
+		{NewFakeRepositories("getBranchError"), "", "could not get fork branch"},
+		{NewFakeRepositories("success"), "c52f25f54838f1052ed9418b65250b422c108926", ""},
+	}
+
+	for _, tc := range testCases {
+		actualSHA, actualErr := getBranchSHA(tc.fr, "chaseadamsio", "updateforks", "master")
+		if actualSHA != tc.expectedSHA {
+			t.Errorf("SHA response for getBranchSHA() expected: %s actual: %s", tc.expectedSHA, actualSHA)
+		}
+
+		if actualErr != nil {
+			if !strings.Contains(actualErr.Error(), tc.expectedErrContains) {
+				t.Errorf("err getAllRepositories() expected: %s actual: %s", tc.expectedErrContains, actualErr)
+			}
+		}
+	}
+}
+
+func TestIsForkUpToDateWithUpstream(t *testing.T) {
+	fork := &Fork{
+		Name:          *expectedRepositories[0].Name,
+		FullName:      *expectedRepositories[0].FullName,
+		Owner:         *expectedRepositories[0].Owner.Login,
+		DefaultBranch: *expectedRepositories[0].DefaultBranch,
+		UpstreamOwner: "chaseadamsio",
+	}
+
+	testCases := []struct {
+		fr                  *FakeRepositories
+		fork                Fork
+		expectedUpToDate    bool
+		expectedErrContains string
+	}{
+		{NewFakeRepositories("getBranchError"), *fork, false, "could not get fork branc SHA"},
+		{NewFakeRepositories("getUpstreamBranchError"), *fork, false, "could not get upstream branch SHA"},
+		{NewFakeRepositories("successUpToDate"), *fork, true, ""},
+		{NewFakeRepositories("successNotUpToDate"), *fork, false, ""},
+	}
+
+	for _, tc := range testCases {
+		actualUpToDate, actualErr := isForkUpToDateWithUpstream(tc.fr, tc.fork)
+		if actualUpToDate != tc.expectedUpToDate {
+			t.Errorf("isForkUpToDateWithUpstream() expected: %b actual: %b", tc.expectedUpToDate, actualUpToDate)
+		}
+
+		if actualErr != nil {
+			if !strings.Contains(actualErr.Error(), tc.expectedErrContains) {
+				t.Errorf("err getAllRepositories() expected: %s actual: %s", tc.expectedErrContains, actualErr)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Refactoring so that this can be used as a static binary by anybody in any github instance!

- replaces `chaseadamsio` with `--user` flag, makes it required by checking before running
- replaces `https://api.github.com` with `--uri` flag that defaults to the original uri
- replaces `v3` with `--api-version` flag that defaults to the original api version 